### PR TITLE
Publish job - return success only if packets were published without errors

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-vp=1.6.2
+vp=1.6.3
 vs=
 AssemblyVersion=%vp%.0

--- a/src/app/Steinpilz.DevFlow.Fake.Lib/lib.fs
+++ b/src/app/Steinpilz.DevFlow.Fake.Lib/lib.fs
@@ -288,7 +288,7 @@ let setup setParams =
                 | Some apiKey -> sprintf " -ApiKey %s" apiKey
                 | None -> ""
 
-            runNuGet (args + apiKeyArgs) param.PublishDir |> ignore
+            runNuGet (args + apiKeyArgs) param.PublishDir |> ensureSuccessExitCode
         )
 
     // Targets


### PR DESCRIPTION
Publish job - return success only if packets were published without errors
As we'd like to use build Publish for fria2-modules in CI/CD and we need red job if packets were not published